### PR TITLE
Add Maintainers and Contribution guidelines

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,9 @@
 #            drawn from different organisations.  Primary ownership is by scoped
 #            GitHub Teams (created under the OpenCHAMI org) rather than individuals.
 #  Rule order Top -> bottom; first match wins.
+# OpenCHAMI  –  Default CODEOWNERS for all repos that do NOT define their own.
+# Each service repo (smd, bss, magellan, …) should have its own simple
+# CODEOWNERS file that points to the appropriate maintainer team.  See below
 # ------------------------------------------------------------------------------
 
 #  Global fallback – anything not caught by a later rule
@@ -21,26 +24,14 @@
 /docs/**                        @openchami/docs-team
 /community/**                   @openchami/community-team
 
-# Core Services
-smd/**                          @openchami/smd-maintainers
-bss/**                          @openchami/bss-maintainers
-scheduler/**                    @openchami/scheduler-maintainers
-magellan/**                     @openchami/magellan-maintainers
-image-builder/**                @openchami/image-builder-maintainers
-cloud-init/**                   @openchami/cloud-init-maintainers
-coresmd/**                      @openchami/coresmd-maintainers
 
 # Build & CI tooling
 build/**                        @openchami/build-wg
 docker/**                       @openchami/build-wg
-.github/workflows/**            @openchami/ci-cd
+.github/**                      @openchami/ci-cd
 
 # Security
 SECURITY.md                     @openchami/security-wg
-keylime/**                      @openchami/security-wg
-
-#  Tests
-tests/**                        @openchami/qa-wg
 
 # RFC / RFD drafts
 rfds/**                         @openchami/rfd-editors

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,57 @@
 @openchami/tsc
+
+# ------------------------------------------------------------------------------
+# OpenCHAMI CODEOWNERS
+#
+#  Purpose  Ensure every change receives review from a *neutral* set of maintainers
+#            drawn from different organisations.  Primary ownership is by scoped
+#            GitHub Teams (created under the OpenCHAMI org) rather than individuals.
+#  Rule order Top -> bottom; first match wins.
+# ------------------------------------------------------------------------------
+
+#  Global fallback – anything not caught by a later rule
+*                           @openchami/tsc
+
+
+
+# Global fallback – if nothing below matches, the TSC reviews
+*                               @openchami/tsc
+
+#  Documentation & community material
+/docs/**                        @openchami/docs-team
+/community/**                   @openchami/community-team
+
+# Core Services
+smd/**                          @openchami/smd-maintainers
+bss/**                          @openchami/bss-maintainers
+scheduler/**                    @openchami/scheduler-maintainers
+magellan/**                     @openchami/magellan-maintainers
+image-builder/**                @openchami/image-builder-maintainers
+cloud-init/**                   @openchami/cloud-init-maintainers
+coresmd/**                      @openchami/coresmd-maintainers
+
+# Build & CI tooling
+build/**                        @openchami/build-wg
+docker/**                       @openchami/build-wg
+.github/workflows/**            @openchami/ci-cd
+
+# Security
+SECURITY.md                     @openchami/security-wg
+keylime/**                      @openchami/security-wg
+
+#  Tests
+tests/**                        @openchami/qa-wg
+
+# RFC / RFD drafts
+rfds/**                         @openchami/rfd-editors
+
+
+# ------------------------------------------------------------------------------
+# Notes
+# • Teams like @openchami/smd-maintainers should contain *at least two* people
+#   from different member organisations to keep governance vendor-neutral.
+# • The @openchami/tsc team should include all current TSC members and acts as
+#   the “catch-all” reviewer if no more-specific match exists.
+# • Update this file whenever you add a new top-level directory or create a
+#   dedicated working group.
+# ------------------------------------------------------------------------------

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,5 @@
 # Contributor Covenant Code of Conduct
+**Version 2.1 – adopted by OpenCHAMI, a Linux Foundation / HPSF project**
 
 ## Our Pledge
 
@@ -13,8 +14,7 @@ We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
 
 ## Our Standards
-
-Examples of behavior that contributes to a positive environment for our
+### Examples of behavior that contributes to a positive environment for our
 community include:
 
 * Demonstrating empathy and kindness toward other people
@@ -25,7 +25,7 @@ community include:
 * Focusing on what is best not just for us as individuals, but for the
   overall community
 
-Examples of unacceptable behavior include:
+### Examples of unacceptable behavior include:
 
 * The use of sexualized language or imagery, and sexual attention or
   advances of any kind
@@ -59,8 +59,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+reported to the community leaders responsible for enforcement at 
+[contact@openchami.org](contact@openchami.org) 
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing Guidelines
 
 
-Welcome to OpenCHAMI. We are excited about the prospect of you joining our [community](https://github.com/openchami/community)! The OpenCHAMI community abides by a standard open source [code of conduct](CODE_OF_CONDUCT.md). Here is an excerpt:
+Welcome to **OpenCHAMI** — a Linux Foundation Projects (LFP) / HPC Software Foundation (HPSF) community project. We are excited about the prospect of you joining our [community](https://github.com/openchami/community)! The OpenCHAMI community abides by a standard open source [code of conduct](CODE_OF_CONDUCT.md). Here is an excerpt:
 
 _As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
 
@@ -30,6 +30,41 @@ Don't get discouraged!  The first rule of open source contribution is, *"Yes is 
 - Code comments are great signposts to help us follow your logic.
 - Smaller PRs are easier to review.  Can you split this up?
 - Correctness proofs are awesome.  Include them in the description/readme/docs/tests wherever they are most appropriate for your code.
+
+## Developer Certificate of Origin(DCO)
+
+### DCO / CLA & Test Requirements
+
+OpenCHAMI is an **LF Projects / HPSF** project.  To protect contributors and downstream users, we require **either** a Developer Certificate of Origin (**DCO**) sign-off **or** signature on our Contributor License Agreement (**CLA**).  Most individual contributors will use the DCO; corporate contributors may prefer the EasyCLA workflow.
+
+---
+
+### Developer Certificate of Origin (DCO)
+
+
+
+**Configure Git with your real name & email** (one-time):
+   ```bash
+   git config --global user.name  "Your Name"
+   git config --global user.email "you@example.com"
+```
+
+#### Signing Your Work  (DCO & Cryptographic Signatures)
+
+OpenCHAMI uses the **Developer Certificate of Origin (DCO)**. Each commit must contain a
+`Signed-off-by:` line, which you add with `git commit -s`.
+
+GitHub fully supports this as an extra layer of verification:
+
+> See GitHub Docs
+> <https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits>
+
+Both the DCO *and* a valid cryptographic signature (if you choose to enable one) will
+be checked by our CI bots. Forgotten to sign? Simply amend and force-push:
+```bash
+git commit --amend -s   # add the DCO line
+git push --force
+```
 
 ## Contact Information
 

--- a/GOVERNANCE.MD
+++ b/GOVERNANCE.MD
@@ -1,59 +1,99 @@
 # Governance of the OpenCHAMI Project
+_Last updated: April 2025_
 
-This file describes the current governance of the OpenCHAMI Poject. It was last updated in January 2025.
-
+This file describes the current governance of the OpenCHAMI Project. 
 In accordance with the [charter](CHARTER.MD), the Technical Steering Committee (TSC) is responsible for technical guidance of the project.
 
-## Technical Leadership
+## 1. Technical Leadership
 
-**Technical Steering Committee Lead:**  [Alex Lovell-Troy](https://github.com/alexlovelltroy)
+### 1.1 Technical Steering Committee (TSC)
+
+| Role | Incumbent | Term | Selection |
+|------|-----------|------|-----------|
+| **TSC Lead** | [Alex Lovell‑Troy](https://github.com/alexlovelltroy) | Apr 2025 – Mar 2026 | Elected annually by TSC simple‑majority vote |
+
 
 Role: As stated in the [Contribution Guide](CONTRIBUTING.md), the TSC lead is responsible for acting as a bridge between the TSC and the Board.  In order to effectively guide the project, the lead must be aware of the major issues and roadmap of the project and priorities of the consortium partners.  He or She is expected to help guide decisions in ways that are technically sound and responsive to the needs of the community.
 
-## Board Of Directors
+#### 1.1.1 Adding / Removing TSC Members
+* Any contributor may self‑nominate or be nominated via a pull request to `community/tsc-rollups.md`.  
+* Approval by existing TSC members requires **⅔ majority** of those voting.  
+* Persistent inactivity (> 6 months) may trigger a removal vote.
+
+#### 1.1.2 Decision‑Making
+The TSC follows a **consensus‑seeking model**:
+1. Discussion on GitHub Issues / PRs or in scheduled TSC calls.  
+2. Rough consensus is assumed unless objections are raised.  
+3. If consensus cannot be reached, a vote is called; decisions pass with **simple majority** (> 50 %).  
+4. **Breaking/architecture‑wide changes** require a **⅔ super‑majority**.
+
+---
+
+## 2. Governing Board (Board Of Directors) 
 
 Membership on the board is granted permanently to the founding institutions and one representative from the Technical Steering Committee (the TSC). A founding institution is required to submit in writing to the board its intention to leave the project or the board. Each founding institution and the TSC is granted one vote on the board. Each founding institution appoints a representative and one alternate member. The TSC will be required to send one member to attend all board activities. The board shall define in these rules the mechanism by which members of the board will be accepted and removed. Unless otherwise stipulated, votes are carried by a simple majority of voting members.
 
-### Board Membership
+### 2.1 Board Membership
 
 The Board comprises members nominated by the founding partners and non-founding partners that fulfill the membership criteria.
 
 Each founding partner must nominate one primary and one alternate Board member. Both individuals have the right to attend board meetings, but only the primary Board member has voting rights, unless the primary member is unavailable.
 
+
+### 2.2 Composition
+
+| Partner | Primary | Alternate |
+|---------|---------|-----------|
+| CSCS | Thomas Schulthess | Mark Klein |
+| HPE | Larry Kaplan | Andy Garside |
+| LANL | Travis Cotton | Gary Grider |
+| NERSC | Eric Roman | Brian Friesen |
+| University of Bristol | Sadaf Alam | Christopher Woods |
+| **TSC Rep** | Elected yearly by the TSC | — |
+
+### 2.3 Voting & Quorum
+* **Quorum:** 50 % of voting members.  
+* **Simple majority** approves routine motions; **⅔** required for budget, Charter changes, or dissolution.
+
+### 2.3 Admission of New Members
 The Board is expanded by the inclusion of non-founding partners who have demonstrated their commitment to the Consortium by dedicating resources to the project and delivering on that commitment for at least six consecutive months.
 
 Non-founding partners must be nominated by an existing partner and accepted by a majority vote of the Board. Upon acceptance, non-founding partners have the right to nominate a primary and alternate Board member.
 
 There can be no non-voting members of the Board. All Board members have an equal vote.
 
-* CSCS
-  - Thomas Schulthess
-  - Mark Klein (Alternate)
-* HPE
-  - Larry Kaplan
-  - Andy Garside (Alternate)
-* LANL
-  - Travis Cotton
-  - Gary Grider (Alternate)
-* NERSC
-  - Eric Roman
-  - Brian Friesen (Alternate)
-* University of Bristol
-  - Sadaf Alam
-  - Christopher Woods (Alternate)
+---
 
-## Special Interest Groups and Technical Working Groups
+## 3. Special Interest Groups (SIGs) & Working Groups (WGs)
 
 It is the responsibility of the TSC to organize SIGs and temporary working groups to address technical issues based on the needs of the community.  Any project participant may suggest a SIG for long term focus or a working group for a short term project through a pull request to the community repository that creates a directory for the SIG and a readme based on the [prototype](https://github.com/OpenCHAMI/community/blob/main/prototypes/sig-README-template.md).
 
-## Technical Standards
+
+---
+
+## 4. Technical Standards Process
 
 The TSC is responsible for the quality of technical changes to the project.  In order to facilitate robust and transparent discussion surrounding the standards, the TSC has created a structured area for discussion in this repository under [rfds](/rfds/) that is loosely based on earlier work from the [IETF](https://datatracker.ietf.org/doc/html/rfc3) and the team at [Oxide.Computer](https://oxide.computer/blog/rfd-1-requests-for-discussion)
 
-## Values
+---
 
-[See Values Document](/values.md)
+## 5. Community Values
 
-## Code of Conduct
+See **[Values Document](values.md)** for the principles that guide our collaboration.
+
+---
+
+## 6. Code of Conduct
 
 The OpenCHAMI project follows version 2.0 of the [Contributor Covenant](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html) with any changes noted locally in our own [Code of Conduct](/code-of-conduct.md)
+
+---
+
+## 7. License
+
+Unless otherwise noted, all source code is released under the **MIT License**.  
+By contributing, you agree that your contributions will be licensed under the same terms.
+
+---
+
+_Disputes or questions about this document may be raised with the TSC or escalated to LF Projects staff at [projects@linuxfoundation.org](mailto:projects@linuxfoundation.org)._ 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,21 +21,19 @@ It complements `CODEOWNERS`, which GitHub uses to request reviews automatically.
 
 ## 2. Service-specific Maintainers 
 _Last updated: April 2025_
-
-| Service / Repo Path | GitHub Team | Maintainers † | Primary Responsibilities |
-|---------------------|------------|---------------|--------------------------|
-| `smd/**` | **@openchami/smd-maintainers** | Alex Lovell-Troy, Shane Unruh | State Management Database – node inventory & ad-hoc groups |
-| `bss/**` | **@openchami/bss-maintainers** | Devon Bautista, Mitchell Schooler | Boot Script Service – generates iPXE scripts for diskless/diskful nodes |
-| `magellan/**` | **@openchami/magellan-maintainers** | David Allen, Alex Lovell-Troy(?) | Redfish-based node discovery & firmware management |
-| `image-builder/**` | **@openchami/image-builder-maintainers** | Travis Cotton, Devon Bautista(?) | Build squashfs images for remote-boot HPC nodes |
-| `cloud-init/**` | **@openchami/cloud-init-maintainers** | Alex Lovell-Troy, Travis Cotton(?) | Generate cloud-init payloads; optional WireGuard TLS |
-| `coresmd/**` | **@openchami/coresmd-maintainers** | Devon Bautista, Travis Raines | CoreDHCP plugin that syncs DHCP data from SMD |
-| `.github/**` | **@openchami/build-wg** | Alex Lovell-Troy , Yogi Porla(?) | Build tooling, Dockerfiles, CI/CD pipelines |
-| `ochami/**` | **@openchami/ochami-team** | Devon Bautista, Alex Lovell-Troy | ochami: OpenCHAMI Command Line Interface |
-| `docs/**`, `openchami.org/**` | **@openchami/docs-team** | Yogi Porla, Alex Lovell-Troy | End-user & developer documentation |
-| `rfds/**` | **@openchami/rfd-editors** | Alex Lovell-Troy, Travis Raines | Request-for-Discussion drafts & editorial workflow |
-| `*` (fallback) | **@openchami/tsc** | All TSC members | Catch-all reviews & dispute resolution |
-  
+| Repository | GitHub Team | Maintainers † | Primary Responsibilities |
+|------------|-------------|---------------|--------------------------|
+| `smd` | **@openchami/smd-maintainers** | Alex Lovell-Troy, Shane Unruh | State Management DB – inventory & ad-hoc groups |
+| `bss` | **@openchami/bss-maintainers** | Devon Bautista, Mitchell Schooler | Boot Script Service – iPXE scripts |
+| `magellan` | **@openchami/magellan-maintainers** | David Allen, Alex Lovell-Troy | Redfish node discovery & firmware mgmt. |
+| `image-builder` | **@openchami/image-builder-maintainers** | Travis Cotton, Devon Bautista | Build squashfs images for remote-boot nodes |
+| `cloud-init` | **@openchami/cloud-init-maintainers** | Alex Lovell-Troy, Travis Cotton | Generate cloud-init payloads & optional WireGuard |
+| `coresmd` | **@openchami/coresmd-maintainers** | Devon Bautista, Travis Raines | CoreDHCP plugin syncing DHCP ↔ SMD |
+| `.github` | **@openchami/build-wg** | Alex Lovell-Troy, Yogi Porla | Org-wide workflows, Dockerfiles, CI/CD |
+| `ochami` (CLI) | **@openchami/ochami-team** | Devon Bautista, Alex Lovell-Troy | OpenCHAMI command-line interface |
+| `docs-site` / `openchami.org` | **@openchami/docs-team** | Yogi Porla, Alex Lovell-Troy | End-user & developer documentation |
+| `rfds` | **@openchami/rfd-editors** | Alex Lovell-Troy, Travis Raines | RFD drafts & editorial workflow |
+| _Any other repo_ | **@openchami/tsc** | All TSC members | Catch-all reviews & dispute resolution |
 Update this table whenever new maintainers or teams are added. docs and rfds are yet to be ported
 
 Each team owns day-to-day decisions for its directory and is the first-line reviewer on pull requests, as enforced by `CODEOWNERS`.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,76 @@
+# OpenCHAMI • Maintainers Guide
+_Last updated : April 2025_
+
+This file lists the current maintainers, their areas of responsibility, and how new maintainers are added or retired.  
+It complements `CODEOWNERS`, which GitHub uses to request reviews automatically.
+
+---
+
+## 1. Project-wide Roles
+
+| Team (GitHub) | Purpose | Current Members (↗ handle) |
+|---------------|---------|----------------------------|
+| **@openchami/tsc** | Technical direction, dispute resolution, top-level reviews | @alexlovelltroy • _TSC lead_ <br> @sadaf-alam <br> … |
+| **@openchami/security-wg** | Security policy, vulnerability triage, keylime integration | @larry-kaplan <br> @travis-cotton |
+| **@openchami/docs-team** | End-user docs, API references, website content | @eric-roman <br> @brian-friesen |
+| **@openchami/ci-cd** | CI/CD workflows, linters, release automation | @mark-klein <br> @andy-garside |
+
+*(Teams must contain maintainers from at least **two distinct organisations** to ensure neutral governance.)*
+
+---
+
+## 2. Service-specific Maintainers 
+_Last updated: April 2025_
+
+| Service / Repo Path | GitHub Team | Maintainers † | Primary Responsibilities |
+|---------------------|------------|---------------|--------------------------|
+| `smd/**` | **@openchami/smd-maintainers** | Travis Cotton(?), Gary Grider(?) | State Management Database – node inventory & ad-hoc groups |
+| `bss/**` | **@openchami/bss-maintainers** | Eric Roman(?), Brian Friesen(?) | Boot Script Service – generates iPXE scripts for diskless/diskful nodes |
+| `scheduler/**` | **@openchami/scheduler-maintainers** | Larry Kaplan(?), Sadaf Alam(?) | Job-scheduler plugins & integration |
+| `magellan/**` | **@openchami/magellan-maintainers** | Thomas Schulthess(?), Mark Klein(?) | Redfish-based node discovery & firmware management |
+| `image-builder/**` | **@openchami/image-builder-maintainers** | Andy Garside(?), Christopher Woods(?) | Build squashfs images for remote-boot HPC nodes |
+| `cloud-init/**` | **@openchami/cloud-init-maintainers** | Brian Friesen(?), Travis Cotton(?) | Generate cloud-init payloads; optional WireGuard TLS |
+| `coresmd/**` | **@openchami/coresmd-maintainers** | Gary Grider(?), Sadaf Alam(?) | CoreDHCP plugin that syncs DHCP data from SMD |
+| `build/**`, `docker/**`, `.github/workflows/**` | **@openchami/build-wg** | Mark Klein(?), Andy Garside(?) | Build tooling, Dockerfiles, CI/CD pipelines |
+| `docs/**`, `website/**` | **@openchami/docs-team** | Eric Roman(?), Brian Friesen(?) | End-user & developer documentation |
+| `tests/**` | **@openchami/qa-wg** | Larry Kaplan(?), (?) | Integration & regression test suites |
+| `rfds/**` | **@openchami/rfd-editors** | Alex Lovell-Troy(?), Thomas Schulthess(?) | Request-for-Discussion drafts & editorial workflow |
+| `*` (fallback) | **@openchami/tsc** | All TSC members | Catch-all reviews & dispute resolution |
+
+† Maintainer names sourced from the contributor lists on <https://github.com/OpenCHAMI#software>.  
+Update this table whenever new maintainers or teams are added.
+
+Each team owns day-to-day decisions for its directory and is the first-line reviewer on pull requests, as enforced by `CODEOWNERS`.
+---
+
+## 3. Maintainer Expectations
+
+* **Review cadence:** Aim to respond to PRs and issues within **2 business days**.  
+* **Consensus > Majority:** Seek agreement in the team; escalate to `@openchami/tsc` only when consensus fails.  
+* **Quality gate:** Merges require green CI, DCO/CLA sign-off, and at least **one review** from the owning team *plus* a second from any other maintainer.  
+* **Community conduct:** Maintainers are stewards of the [Code of Conduct](code_of_conduct.md) and model respectful collaboration.  
+
+---
+
+## 4. Becoming a Maintainer
+
+1. **Contribute regularly** for ~3 months (code, docs, reviews, triage).  
+2. **Receive nominations** from any existing maintainer (open a PR adding your GitHub handle to the relevant team list in this file).  
+3. **Lazy consensus period:** 5 business days for objections on the PR. If none, the nomination is accepted.  
+4. **Update GitHub team:** A TSC member adds the new maintainer to the appropriate team.  
+
+> _Note: Maintainers who are inactive for 6 months may be moved to Emeritus status by TSC vote._
+
+---
+
+## 5. Escalation & Contact
+
+| Situation | Contact |
+|-----------|---------|
+| Code-of-Conduct concern | <coc@openchami.org> (or escalate to conduct@lfprojects.org) |
+| Security vulnerability | <security@openchami.org> (PGP key on website) |
+| Build/CI outage | `#ci-cd` Slack channel • mention **@openchami/ci-cd** |
+| Project governance question | Email **tsc@openchami.org** or open `community` repo issue |
+
+---
+

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,21 +24,19 @@ _Last updated: April 2025_
 
 | Service / Repo Path | GitHub Team | Maintainers † | Primary Responsibilities |
 |---------------------|------------|---------------|--------------------------|
-| `smd/**` | **@openchami/smd-maintainers** | Travis Cotton(?), Gary Grider(?) | State Management Database – node inventory & ad-hoc groups |
-| `bss/**` | **@openchami/bss-maintainers** | Eric Roman(?), Brian Friesen(?) | Boot Script Service – generates iPXE scripts for diskless/diskful nodes |
-| `scheduler/**` | **@openchami/scheduler-maintainers** | Larry Kaplan(?), Sadaf Alam(?) | Job-scheduler plugins & integration |
-| `magellan/**` | **@openchami/magellan-maintainers** | Thomas Schulthess(?), Mark Klein(?) | Redfish-based node discovery & firmware management |
-| `image-builder/**` | **@openchami/image-builder-maintainers** | Andy Garside(?), Christopher Woods(?) | Build squashfs images for remote-boot HPC nodes |
-| `cloud-init/**` | **@openchami/cloud-init-maintainers** | Brian Friesen(?), Travis Cotton(?) | Generate cloud-init payloads; optional WireGuard TLS |
-| `coresmd/**` | **@openchami/coresmd-maintainers** | Gary Grider(?), Sadaf Alam(?) | CoreDHCP plugin that syncs DHCP data from SMD |
-| `build/**`, `docker/**`, `.github/workflows/**` | **@openchami/build-wg** | Mark Klein(?), Andy Garside(?) | Build tooling, Dockerfiles, CI/CD pipelines |
-| `docs/**`, `website/**` | **@openchami/docs-team** | Eric Roman(?), Brian Friesen(?) | End-user & developer documentation |
-| `tests/**` | **@openchami/qa-wg** | Larry Kaplan(?), (?) | Integration & regression test suites |
-| `rfds/**` | **@openchami/rfd-editors** | Alex Lovell-Troy(?), Thomas Schulthess(?) | Request-for-Discussion drafts & editorial workflow |
+| `smd/**` | **@openchami/smd-maintainers** | Alex Lovell-Troy, Shane Unruh | State Management Database – node inventory & ad-hoc groups |
+| `bss/**` | **@openchami/bss-maintainers** | Devon Bautista, Mitchell Schooler | Boot Script Service – generates iPXE scripts for diskless/diskful nodes |
+| `magellan/**` | **@openchami/magellan-maintainers** | David Allen, Alex Lovell-Troy(?) | Redfish-based node discovery & firmware management |
+| `image-builder/**` | **@openchami/image-builder-maintainers** | Travis Cotton, Devon Bautista(?) | Build squashfs images for remote-boot HPC nodes |
+| `cloud-init/**` | **@openchami/cloud-init-maintainers** | Alex Lovell-Troy, Travis Cotton(?) | Generate cloud-init payloads; optional WireGuard TLS |
+| `coresmd/**` | **@openchami/coresmd-maintainers** | Devon Bautista, Travis Raines | CoreDHCP plugin that syncs DHCP data from SMD |
+| `.github/**` | **@openchami/build-wg** | Alex Lovell-Troy , Yogi Porla(?) | Build tooling, Dockerfiles, CI/CD pipelines |
+| `ochami/**` | **@openchami/ochami-team** | Devon Bautista, Alex Lovell-Troy | ochami: OpenCHAMI Command Line Interface |
+| `docs/**`, `openchami.org/**` | **@openchami/docs-team** | Yogi Porla, Alex Lovell-Troy | End-user & developer documentation |
+| `rfds/**` | **@openchami/rfd-editors** | Alex Lovell-Troy, Travis Raines | Request-for-Discussion drafts & editorial workflow |
 | `*` (fallback) | **@openchami/tsc** | All TSC members | Catch-all reviews & dispute resolution |
-
-† Maintainer names sourced from the contributor lists on <https://github.com/OpenCHAMI#software>.  
-Update this table whenever new maintainers or teams are added.
+  
+Update this table whenever new maintainers or teams are added. docs and rfds are yet to be ported
 
 Each team owns day-to-day decisions for its directory and is the first-line reviewer on pull requests, as enforced by `CODEOWNERS`.
 ---


### PR DESCRIPTION

Adopt Code of Conduct -  Publish Contributor Covenant in CODE_OF_CONDUCT.md and assign enforcers.
Document Governance Model - Review GOVERNANCE.md explaining Board/TSC roles and decision flow.
Define Roles & Permissions -  Create contributor ladder and GitHub Teams (maintainer, committer, triager).
Neutral Project Ownership - Confirm all assets are under LF Projects to assure neutral IP control.
Shared Contribution Guidelines -  Centralize org‑wide rules in a .github repo for automatic inheritance.


