### PR TITLE
Governance: point to community as canonical; remove member lists from…

### DIFF
--- a/CHARTER.MD
+++ b/CHARTER.MD
@@ -1,72 +1,33 @@
 # Technical Charter (the “Charter”) for OpenCHAMI a Series of LF Projects, LLC
 
-## 1. Introduction  
+## Introduction  
 This Charter sets forth the responsibilities and procedures for technical contribution to, and oversight of, the OpenCHAMI open source project, which has been established as OpenCHAMI a Series of LF Projects, LLC (the “Project”). LF Projects, LLC (“LF Projects”) is a Delaware series limited liability company. All contributors (including committers, maintainers, and other technical positions) and other participants in the Project (collectively, “Collaborators”) must comply with the terms of this Charter.  
 
-## 2. Mission and Scope of the Project  
+## Mission and Scope of the Project  
 The mission of the Project is to steward the collaborative development and continuous evolution of cloud-like software to manage High Performance Computing capacity regardless of the size or deployment platform.  
 
 The scope of the Project includes collaborative development under the Project License (as defined herein) supporting the mission, including documentation, testing, integration, and the creation of other artifacts that aid the development, deployment, operation, or adoption of the open source project.  
 
-## 3. Technical Steering Committee (TSC)  
-The **Technical Steering Committee (TSC)** will be responsible for all technical oversight of the open source Project.  
 
-- The TSC voting members are initially the Project’s **Committers**.  
-- At the inception of the project, the Committers of the Project will be as set forth within the *CONTRIBUTING* file within the Project’s code repository.  
-- The TSC may choose an alternative approach for determining the voting members of the TSC, and any such alternative approach will be documented in the *CONTRIBUTING* file.  
-- Any meetings of the TSC are intended to be **open to the public** and can be conducted electronically, via teleconference, or in person.  
-
-### 3.1 Roles within the TSC  
-TSC projects generally involve **Contributors** and **Committers**. The TSC may adopt or modify roles, documented in the *CONTRIBUTING* file.  
-
-- **Contributors**: Anyone in the technical community that contributes code, documentation, or other technical artifacts to the Project.  
-- **Committers**: Contributors who have earned the ability to modify (“commit”) source code, documentation, or other technical artifacts in a project’s repository.  
-- A **Contributor** may become a **Committer** by a majority approval of the existing Committers.  
-- A **Committer** may be removed by a majority approval of the other existing Committers.  
-
-Participation in the Project through becoming a Contributor and Committer is **open to anyone** so long as they abide by the terms of this Charter.  
-
-### 3.2 Responsibilities of the TSC  
-The TSC will oversee all aspects of the Project, including:  
-
-- Coordinating the technical direction of the Project.  
-- Approving project or system proposals (e.g., incubation, deprecation, scope changes).  
-- Organizing and removing sub-projects.  
-- Creating sub-committees or working groups for cross-project issues.  
-- Appointing representatives to work with other open source or open standards communities.  
-- Establishing community norms, workflows, and security issue reporting policies.  
-- Approving and implementing contribution policies (*to be published in the CONTRIBUTING file*).  
-- Coordinating with the Series Manager to resolve matters as set forth in Section 7.  
-- Managing project-related marketing, events, and communications.  
-
-## 4. TSC Voting  
-The Project aims to operate as a **consensus-based** community. If a vote is required:  
-
-- Each TSC voting member has **one vote**.  
-- **Quorum** requires at least **50% of all voting members**.  
-- Decisions at a meeting require a **majority vote of those present**, provided quorum is met.  
-- Electronic votes require a **majority vote of all voting members**.  
-- If a vote cannot be resolved, any voting TSC member may refer the matter to the **Series Manager** for assistance.  
-
-## 5. Compliance with Policies  
+## Compliance with Policies  
 This Charter is subject to the **Series Agreement** and **Operating Agreement** of LF Projects.  
 
 - Contributors must comply with **LF Projects’ policies**: [LF Projects Policies](https://lfprojects.org/policies/).  
 - The TSC may adopt a **Code of Conduct (CoC)**, subject to approval by the **Series Manager**. If not, the LF Projects **CoC** applies.  
 - The Project must remain **transparent, open, collaborative, and ethical** at all times.  
 
-## 6. Community Assets  
+## Community Assets  
 - LF Projects will **hold title** to all trademarks used by the Project (*Project Trademarks*).  
 - The Project will manage its own **GitHub, social media accounts, and domain names**.  
 - LF Projects will not be expected to undertake actions that contradict its tax-exempt status.  
 
-## 7. General Rules and Operations  
+## General Rules and Operations  
 The Project will:  
 
 - Engage professionally and maintain goodwill within the open source community.  
 - Respect all **trademark owners** and branding guidelines.  
 
-## 8. Intellectual Property Policy  
+## Intellectual Property Policy  
 - Copyright in all new contributions remains with the original author.  
 - **All new inbound code contributions** must use the **MIT License** ([MIT License](https://opensource.org/licenses/MIT)).  
 - All contributions must be **accompanied by a Developer Certificate of Origin (DCO)** ([DCO](http://developercertificate.org)).  
@@ -76,5 +37,5 @@ The Project will:
 - The TSC may approve **license exceptions** by a **two-thirds vote**.  
 - Contributed files should use **SPDX short-form identifiers** for license information.  
 
-## 9. Amendments  
+## Amendments  
 This Charter may be **amended** by a **two-thirds vote of the entire TSC**, subject to **LF Projects’ approval**.  

--- a/GOVERNANCE.MD
+++ b/GOVERNANCE.MD
@@ -1,90 +1,29 @@
 # Governance of the OpenCHAMI Project
-_Last updated: May 2025_
+_Last updated: Aug 2025_
 
-This file describes the current governance of the OpenCHAMI Project. 
-In accordance with the [charter](CHARTER.MD), the Technical Steering Committee (TSC) is responsible for technical guidance of the project.
+This repository provides high-level, organization-wide docs (e.g., Contribution Guide, Code of Conduct, Charter).  
+**Canonical governance details now live in the `OpenCHAMI/community` repository.**
 
-## 1. Technical Leadership
+- **Charter** (high-level LF Projects & TSC scope)
+- **Governance Process (canonical):** https://github.com/OpenCHAMI/community/blob/main/GOVERNANCE.md
+- **TSC Membership (canonical):** https://github.com/OpenCHAMI/community/blob/main/TSC/tsc-rollups.md
+- **Board Membership (canonical):** https://github.com/OpenCHAMI/community/blob/main/Board/board-rollups.md
 
-### 1.1 Technical Steering Committee (TSC)
+## Decision-Making (Summary)
+- Consensus-seeking; if needed, simple-majority vote of eligible voters.
+- SIGs/WGs proposals and technical changes occur transparently via GitHub issues/PRs.
 
-| Role | Incumbent | Term | Selection |
-|------|-----------|------|-----------|
-| **TSC Lead** | [Alex Lovell‑Troy](https://github.com/alexlovelltroy) | Apr 2025 – Mar 2026 | Elected annually by TSC simple‑majority vote |
-
-
-Role: As stated in the [Contribution Guide](CONTRIBUTING.md), the TSC lead acts as a bridge between the TSC and the Board. To effectively guide the project, the lead must stay informed about major issues, the project roadmap, and priorities of consortium partners. They are expected to help guide decisions in ways that are technically sound and responsive to community needs.
-
-#### 1.1.1 TSC Members
-
-| Member | GitHub handle | Affiliation |
-|--------|--------------|-------------|
-| Alex Lovell‑Troy | [@alexlovelltroy](https://github.com/alexlovelltroy) | LANL |
-| Mark Klein | [@mdklein](https://github.com/mdklein) | CSCS |
-| Matt Williams | [@milliams](https://github.com/milliams) | University of Bristol (BriCS) |
-| Brian Friesen | [@bcfriesen](https://github.com/bcfriesen) | NERSC |
-| Harold Longley | [@haroldlongley](https://github.com/haroldlongley) | HPE |
-
-
-#####  Adding / Removing TSC Members
-* Any contributor may self‑nominate or be nominated via a pull request to [community/TSC repo](https://github.com/OpenCHAMI/community/tree/main/TSC/tsc-rollups.md).  
-* Approval by existing TSC members requires **simple majority** of those voting.  
-* Persistent inactivity (defined as no participation for over 6 months) may trigger a removal vote.
-
-#### 1.1.2 Decision‑Making
-The TSC follows a **consensus‑seeking model**: Please refer to the [charter](CHARTER.MD).
-1. Discussion on GitHub Issues / PRs or in scheduled TSC calls.  
-2. Rough consensus is assumed unless objections are raised.  
-3. If consensus cannot be reached, a vote is called; decisions pass with **simple majority** (> 50 %).  
-
+> For details and the latest membership, always consult the files in `OpenCHAMI/community` linked above.
 ---
 
-## 2. Governing Board (Board Of Directors) 
-
-Membership on the board is granted permanently to the founding institutions and one representative from the Technical Steering Committee (the TSC). A founding institution is required to submit in writing to the board its intention to leave the project or the board. Each founding institution and the TSC is granted one vote on the board. Each founding institution appoints a representative and one alternate member. The TSC will be required to send one member to attend all board activities. The board shall define in these rules the mechanism by which members of the board will be accepted and removed. Unless otherwise stipulated, votes are carried by a simple majority of voting members.
-
-### 2.1 Board Membership
-
-The Board comprises members nominated by the founding partners and non-founding partners that fulfill the membership criteria.
-
-Each founding partner must nominate one primary and one alternate Board member. Both individuals have the right to attend board meetings, but only the primary Board member has voting rights, unless the primary member is unavailable.
-
-
-### 2.2 Composition
-
-| Partner | Primary | Alternate |
-|---------|---------|-----------|
-| CSCS | Thomas Schulthess | Mark Klein |
-| HPE | Larry Kaplan | Andy Garside |
-| LANL | Travis Cotton | Gary Grider |
-| NERSC | Eric Roman | Brian Friesen |
-| University of Bristol | Sadaf Alam | Christopher Woods |
-| **TSC Rep** | Elected yearly by the TSC | — |
-
-### 2.3 Voting & Quorum
-* **Quorum:** 50 % of voting members.  
-* **Simple majority** approves routine motions; **⅔** required for budget, Charter changes, or dissolution.
-* **Conflict resolution:** Conflicts unresolved through voting can be escalated to LF Projects staff at [projects@linuxfoundation.org](mailto:projects@linuxfoundation.org).
-
-
-
-### 2.4 Admission of New Members
-The Board is expanded by the inclusion of non-founding partners who have demonstrated their commitment to the Consortium by dedicating resources to the project and delivering on that commitment for at least six consecutive months.
-
-Non-founding partners must be nominated by an existing partner and accepted by a majority vote of the Board. Upon acceptance, non-founding partners have the right to nominate a primary and alternate Board member.
-
-There can be no non-voting members of the Board. All Board members have an equal vote.
-
----
-
-## 3. Special Interest Groups (SIGs) & Working Groups (WGs)
+## Special Interest Groups (SIGs) & Working Groups (WGs)
 
 It is the responsibility of the TSC to organize SIGs and temporary working groups to address technical issues based on the needs of the community.  Any project participant may suggest a SIG for long term focus or a working group for a short term project through a pull request to the community repository that creates a directory for the SIG and a readme based on the [prototype](https://github.com/OpenCHAMI/community/blob/main/prototypes/sig-README-template.md).
 
 
 ---
 
-## 4. Technical Standards Process
+## Technical Standards Process
 
 The TSC ensures the quality of technical changes. Discussions occur transparently in the repository under [RFDs](https://github.com/OpenCHAMI/roadmap/issues), modeled after practices from the [IETF](https://datatracker.ietf.org/doc/html/rfc3) and [Oxide](https://oxide.computer/blog/rfd-1-requests-for-discussion).
 
@@ -92,26 +31,26 @@ The TSC ensures the quality of technical changes. Discussions occur transparentl
 
 ---
 
-## 5. Community Values
+## Community Values
 
 See **[Values Document](values.md)** for the principles that guide our collaboration.
 
 ---
 
-## 6. Code of Conduct
+## Code of Conduct
 
 The OpenCHAMI project follows version 2.0 of the [Contributor Covenant](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html) with any changes noted locally in our own [Code of Conduct](/code-of-conduct.md)
 
 ---
 
-## 7. License
+## License
 
 Unless otherwise noted, all source code is released under the **MIT License**.  
 By contributing, you agree that your contributions will be licensed under the same terms.
 
 ---
 
-## 8. Communication
+## Communication
 
 OpenCHAMI primarily uses [Slack](https://openchami.slack.com) for community discussions and real-time communication. Technical discussions, proposals, and **Requests for Discussion (RFDs)** occur on [GitHub](https://github.com/OpenCHAMI/roadmap/issues). Community members are encouraged to join the [OpenCHAMI Slack workspace](https://openchami.slack.com) and actively participate in discussions and decision-making processes.
 


### PR DESCRIPTION
Refactored and relocated TSC and BOD to community and added references to these docs 