### PR TITLE
Fix description formatting in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
     id: steps-to-reproduce
     attributes:
       label: Steps to reproduce
-      description: Please list the steps to reproduce the behavior:
+      description: Please list the steps to reproduce the behavior\:
       placeholder: 1. Go to '...'\n2. Click on '....'\n3. Scroll down to '....'\n4. See error
       value: "1. \n2. \n3. \n4. "
     validations:


### PR DESCRIPTION
Escape colon in the description field for clarity.


For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
